### PR TITLE
enable dynamic multi-tenant sharding

### DIFF
--- a/app/controllers/tenanted_controller.rb
+++ b/app/controllers/tenanted_controller.rb
@@ -1,2 +1,16 @@
 class TenantedController < ApplicationController
+  around_action :detect_tenant_db
+
+  private
+
+  def detect_tenant_db
+    TenantRecord.connected_to(shard: shard_name, role: :writing) do
+      yield
+    end
+  end
+
+  def shard_name
+    tenant_id = request.path.match(/\/tenants\/(\d+)\//)[1]
+    :"shard_tenant_#{tenant_id}"
+  end
 end

--- a/app/controllers/tenanted_controller.rb
+++ b/app/controllers/tenanted_controller.rb
@@ -11,6 +11,6 @@ class TenantedController < ApplicationController
 
   def shard_name
     tenant_id = request.path.match(/\/tenants\/(\d+)\//)[1]
-    :"shard_tenant_#{tenant_id}"
+    Common::TenantDbShard.shard_name tenant_id
   end
 end

--- a/app/models/common/tenant_db_connection.rb
+++ b/app/models/common/tenant_db_connection.rb
@@ -1,0 +1,17 @@
+class Common::TenantDbConnection < CommonRecord
+  enum role: { writing: 1, reading: 2 }
+
+  def create_tenant_db_if_not_exists
+    query = "CREATE DATABASE #{database} ENCODING = '#{encoding}'"
+    begin
+      ActiveRecord::Base.connection.execute(query)
+    rescue ActiveRecord::DatabaseAlreadyExists
+      logger.info("PartnerDB already exists: #{database}")
+    end
+  end
+
+  def build_connection_config
+    attributes
+      .slice(*%w[adapter encoding pool host username password database])
+  end
+end

--- a/app/models/common/tenant_db_shard.rb
+++ b/app/models/common/tenant_db_shard.rb
@@ -1,0 +1,29 @@
+class Common::TenantDbShard < CommonRecord
+  has_many :db_connections, class_name: 'Common::TenantDbConnection', foreign_key: 'shard_id'
+
+  class << self
+    def shard_name(tenant_id)
+      :"shard_tenant_#{tenant_id}"
+    end
+
+    def build_shards_config
+      all_shards = all.includes(:db_connections).order(:tenant_id)
+      all_shards
+        .map(&:shard_name)
+        .zip(all_shards.map(&:build_shard_config))
+        .to_h
+    end
+  end
+
+  def shard_name
+    self.class.shard_name(tenant_id).to_sym
+  end
+
+  def build_shard_config
+    db_connections
+      .map(&:role)
+      .map(&:to_sym)
+      .zip(db_connections.map(&:build_connection_config))
+      .to_h
+  end
+end

--- a/app/models/tenant_record.rb
+++ b/app/models/tenant_record.rb
@@ -1,5 +1,8 @@
 class TenantRecord < ApplicationRecord
   self.abstract_class = true
 
-  connects_to database: { writing: :tenant_1, reading: :tenant_1 }
+  connects_to shards: {
+    shard_tenant_1: { writing: :tenant_1, reading: :tenant_1 },
+    shard_tenant_2: { writing: :tenant_2, reading: :tenant_2 },
+  }
 end

--- a/app/models/tenant_record.rb
+++ b/app/models/tenant_record.rb
@@ -1,48 +1,5 @@
 class TenantRecord < ApplicationRecord
   self.abstract_class = true
 
-  connects_to shards: {
-    shard_tenant_1: {
-      writing:
-        {
-          "adapter"=>"postgresql",
-          "encoding"=>"unicode",
-          "pool"=>5,
-          "host"=>"127.0.0.1",
-          "username"=>"postgres",
-          "password"=>nil,
-          "database"=>"multi_tenant_api_tenant_1_development"
-        },
-      reading:
-        {"adapter"=>"postgresql",
-         "encoding"=>"unicode",
-         "pool"=>5,
-         "host"=>"127.0.0.1",
-         "username"=>"postgres",
-         "password"=>nil,
-         "database"=>"multi_tenant_api_tenant_1_development"
-        },
-    },
-    shard_tenant_2: {
-      writing:
-        {
-          "adapter"=>"postgresql",
-          "encoding"=>"unicode",
-          "pool"=>5,
-          "host"=>"127.0.0.1",
-          "username"=>"postgres",
-          "password"=>nil,
-          "database"=>"multi_tenant_api_tenant_2_development"
-        },
-      reading:
-        {"adapter"=>"postgresql",
-         "encoding"=>"unicode",
-         "pool"=>5,
-         "host"=>"127.0.0.1",
-         "username"=>"postgres",
-         "password"=>nil,
-         "database"=>"multi_tenant_api_tenant_2_development"
-        },
-    },
-  }
+  connects_to shards: Common::TenantDbShard.build_shards_config
 end

--- a/app/models/tenant_record.rb
+++ b/app/models/tenant_record.rb
@@ -2,7 +2,47 @@ class TenantRecord < ApplicationRecord
   self.abstract_class = true
 
   connects_to shards: {
-    shard_tenant_1: { writing: :tenant_1, reading: :tenant_1 },
-    shard_tenant_2: { writing: :tenant_2, reading: :tenant_2 },
+    shard_tenant_1: {
+      writing:
+        {
+          "adapter"=>"postgresql",
+          "encoding"=>"unicode",
+          "pool"=>5,
+          "host"=>"127.0.0.1",
+          "username"=>"postgres",
+          "password"=>nil,
+          "database"=>"multi_tenant_api_tenant_1_development"
+        },
+      reading:
+        {"adapter"=>"postgresql",
+         "encoding"=>"unicode",
+         "pool"=>5,
+         "host"=>"127.0.0.1",
+         "username"=>"postgres",
+         "password"=>nil,
+         "database"=>"multi_tenant_api_tenant_1_development"
+        },
+    },
+    shard_tenant_2: {
+      writing:
+        {
+          "adapter"=>"postgresql",
+          "encoding"=>"unicode",
+          "pool"=>5,
+          "host"=>"127.0.0.1",
+          "username"=>"postgres",
+          "password"=>nil,
+          "database"=>"multi_tenant_api_tenant_2_development"
+        },
+      reading:
+        {"adapter"=>"postgresql",
+         "encoding"=>"unicode",
+         "pool"=>5,
+         "host"=>"127.0.0.1",
+         "username"=>"postgres",
+         "password"=>nil,
+         "database"=>"multi_tenant_api_tenant_2_development"
+        },
+    },
   }
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -28,12 +28,6 @@ development:
   common:
     <<: *default
     database: multi_tenant_api_common_development
-  tenant_1:
-    <<: *default
-    database: multi_tenant_api_tenant_1_development
-  tenant_2:
-    <<: *default
-    database: multi_tenant_api_tenant_2_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.

--- a/db/common/Schemafile
+++ b/db/common/Schemafile
@@ -4,3 +4,24 @@ create_table "tenants", force: :cascade do |t|
   t.datetime "created_at", null: false
   t.datetime "updated_at", null: false
 end
+
+create_table "tenant_db_shards", force: :cascade do |t|
+  t.bigint   "tenant_id",  null: false
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+end
+
+create_table "tenant_db_connections", force: :cascade do |t|
+  t.bigint   "shard_id",   null: false
+  t.integer  "role",       null: false, comment: '1: writing, 2: reading'
+  t.string   "adapter",    null: false, default: 'postgresql'
+  t.string   "encoding",   null: false, default: 'unicode'
+  t.integer  "pool",       null: false, default: 5
+  t.string   "host",       null: false
+  t.string   "username",   null: false
+  t.string   "password",   null: true
+  t.string   "database",   null: false
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+end
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,22 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+(1..3).each do |tenant_id|
+  Common::Tenant.find_or_initialize_by(id: tenant_id).tap do |tenant|
+    tenant.update! name: "テナント #{tenant_id}",
+                   email: "tenant_#{tenant_id}@example.com"
+  end
+
+  Common::TenantDbShard.find_or_initialize_by(tenant_id: tenant_id).tap do |db_shard|
+    db_shard.save!
+
+    %w[writing reading].each do |role|
+      Common::TenantDbConnection.find_or_initialize_by(shard_id: db_shard.id, role: role).tap do |db_connection|
+        db_connection.update! host: '127.0.0.1',
+                              username: 'postgres',
+                              database: "multi_tenant_api_tenant_#{sprintf '%08d', tenant_id}_development"
+      end
+    end
+  end
+end

--- a/lib/tasks/ridgepole.rake
+++ b/lib/tasks/ridgepole.rake
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
 namespace :ridgepole do
-  desc 'Apply common database schema'
-  task common_apply: :environment do
-    apply 'common', 'db/common/Schemafile'
+  desc 'Apply schema to common db'
+  task apply_common: :environment do
+    config = Rails.application.config.database_configuration[Rails.env]['common']
+    apply config, 'db/common/Schemafile'
   end
 
-  desc 'Apply tenant database schema'
-  task :tenant_apply, ['tenant_id'] => :environment do |_task, args|
-    apply "tenant_#{args.tenant_id}", 'db/tenant/Schemafile'
+  desc 'Apply schema to tenant dbs'
+  task apply_tenants: :environment do
+    Common::TenantDbConnection.where(role: :writing).each do |db_connection|
+      config = db_connection.build_connection_config
+      apply config, 'db/tenant/Schemafile'
+    end
   end
 
   private
@@ -18,17 +22,13 @@ namespace :ridgepole do
     system((command + options).join(' '))
   end
 
-  def draw_config(db_name)
-    Rails.application.config.database_configuration[Rails.env][db_name.to_s]
-  end
-
-  def shape_config_str(db_name)
-    config_str = draw_config(db_name).to_s
+  def shape_config_str(db_config)
+    config_str = db_config.to_s
     config_str.gsub(/>|=/, '>' => '', '=' => ':')
   end
 
-  def apply(db_name, schema_file)
-    ridgepole("--file #{schema_file}", "--config '#{shape_config_str(db_name)}'", \
+  def apply(config, schema_file)
+    ridgepole("--file #{schema_file}", "--config '#{shape_config_str(config)}'", \
               "--env #{Rails.env}", '--apply')
   end
 end

--- a/lib/tasks/tenant_dbs.rake
+++ b/lib/tasks/tenant_dbs.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :tenant_dbs do
+  desc 'create tenant dbs'
+  task create: :environment do
+    Common::TenantDbConnection.all.each do |db_connection|
+      db_connection.create_tenant_db_if_not_exists
+    end
+  end
+
+  desc 'drop tenant dbs'
+  task drop: :environment do
+    raise 'dropping tenant dbs can development env only' unless Rails.env.development?
+
+    Common::TenantDbConnection.all.each do |db_connection|
+      query = "DROP DATABASE IF EXISTS #{db_connection.database}"
+      CommonRecord.connection.execute query
+    end
+  end
+end


### PR DESCRIPTION
## 方針

multi tenant db を実現するなら、Rails 6.1 で実装された horizontal-sharding を使うのがいいと思う。
rails guide でも horizontal-sharding を 'multi-tenant' sharding と申しております。

https://guides.rubyonrails.org/active_record_multiple_databases.html#horizontal-sharding
https://railsguides.jp/active_record_multiple_databases.html#%E6%B0%B4%E5%B9%B3%E3%82%B7%E3%83%A3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0

Rails API を hack してないので、今後の Rails バージョンアップにも追従しやすいし。

## やったこと

- common db に テナントごとの shard と、そこに紐づく connection (writing, reading) を定義
- tenanted な api の パスには tenant_id を含む構造としたうえで、そこから tenant に対応する shard を設定する
- 各種 DB  構築ツールも rake で書いた

## 制約

tenant が増えた場合（common DBの shard/connection が追加された場合) 
shard の設定をアプリケーション全体に伝播させるには、サーバ再起動が一番手っ取り早いデス。
（別にテナントの増加って超頻繁に起こるわけじゃないし）再起動でイインジャネ？と思ってる。
